### PR TITLE
Task 5: Context-Aware Telemetry Polling Implementation

### DIFF
--- a/PultV1_0_2.ino
+++ b/PultV1_0_2.ino
@@ -46,6 +46,10 @@ uint32_t queueFullTimer = 0;
 bool isManualMoving = false;
 uint32_t manualHeartbeatTimer = 0;
 
+uint32_t lastPollTime = 0;
+uint32_t currentPollInterval = 400;
+uint32_t lastSensorPollTime = 0;
+
 #pragma region переменные
 HardwareSerial &hSerial = Serial2;
 
@@ -224,7 +228,6 @@ uint8_t speedCurr;
 // uint16_t errorcode; // Removed
 // uint8_t warncode; // Removed
 String tempcode;
-uint8_t countcharge = 0;  // count repeat request charge and status
 int16_t speedset = 10;
 int16_t newspeedset = 0;
 uint8_t palletconf = 0;       // get quant pallets
@@ -309,7 +312,6 @@ unsigned long displayOffTimer = 0;
 unsigned long displayOffInterval = 25000;
 unsigned long longPressTime = 1000;
 unsigned long mpingtime = 0;
-unsigned long getchargetime = 0;
 unsigned long checkA0time = 0;
 unsigned long shuttnumOffInterval = 0;
 unsigned long blinkshuttnumInterval = 0;
@@ -321,7 +323,6 @@ int8_t minlevel = 31;
 uint8_t errn = 1;
 uint8_t warrn = 0;
 uint8_t prevpercent = 100;
-uint8_t cyclegetcharge = 0;
 String strmenu[20];
 uint32_t statistic[10];  // = {0,0,0,0,0,0,0,0,0,0};
 uint8_t odometr_pos = 0;
@@ -404,9 +405,6 @@ void setup()
 
   delay(50);
   kpd.addEventListener(keypadEvent);
-  cmdSend(16);
-  countcharge = 0;
-  getchargetime = millis();
   displayOffInterval = 25000;
   rtc_gpio_init((gpio_num_t)13);
   rtc_gpio_set_direction((gpio_num_t)13, RTC_GPIO_MODE_OUTPUT_ONLY);
@@ -467,6 +465,37 @@ void loop()
   }
   handleRx();
   processTxQueue();
+
+  // --- Context-Aware Polling Engine ---
+  if (!isManualMoving && !isOtaUpdating)
+  {
+    // 1. Determine Polling Interval based on Active Page
+    if (page == MAIN) {
+        currentPollInterval = 400;      // Fast updates for main dashboard
+    } else if (page == DEBUG_INFO) {
+        currentPollInterval = 1500;     // Slow heartbeat, fast sensors below
+    } else {
+        currentPollInterval = 1500;     // Background keep-alive for other menus
+    }
+
+    // 2. Execute Heartbeat Polling
+    if (millis() - lastPollTime >= currentPollInterval) {
+        if (queueRequest(SP::MSG_REQ_HEARTBEAT, shuttleNumber)) {
+            lastPollTime = millis();
+        }
+    }
+
+    // 3. Execute Sensor Polling (Specific to DEBUG_INFO)
+    if (page == DEBUG_INFO) {
+        if (millis() - lastSensorPollTime >= 300) {
+             // Only queue if space is available to prevent choking the heartbeat
+             if (queueRequest(SP::MSG_REQ_SENSORS, shuttleNumber)) {
+                lastSensorPollTime = millis();
+             }
+        }
+    }
+  }
+
   // int Result, Status;
 
   String linkMode = " ";
@@ -527,22 +556,6 @@ void loop()
       checkA0time = millis();
       isDisplayDirty = true;
 
-      if (cyclegetcharge > 60)
-      {
-        if (buttonActive == 0)
-        {
-          countcharge = 0;
-          getchargetime = millis();
-        }
-        cyclegetcharge = 0;
-      }
-      else if (
-          cachedTelemetry.shuttleStatus == 11 && buttonActive == 0 &&
-          (cyclegetcharge == 20 || cyclegetcharge == 60 || cyclegetcharge == 100))
-      {
-        cmdSend(35);
-      }
-      cyclegetcharge++;
       if (!digitalRead(Charge_Pin))
       {
         chargercount = 8;
@@ -562,50 +575,6 @@ void loop()
         prevpercent = 100;
         battindicat += 25;
         if (battindicat > 100) battindicat = 0;
-      }
-      if (page == DEBUG_INFO && SensorsDataTrig) cmdSend(44);
-    }
-
-    if (millis() - getchargetime > 300)
-    {
-      uint8_t cc = 3;
-      if (countcharge < cc)
-      {
-        if (page == MAIN)
-        {
-          if (countcharge == 0)
-          {
-             // shuttleStatus = 18;
-          }
-          else if (countcharge == 2)
-          {
-            manualMode = false;
-            newMpr = 0;
-            inputQuant = 0;
-            newshuttleLength = 0;
-            newspeedset = 0;
-            newlowbatt = 100;
-            newreverse = 2;
-            waittime = 0;
-            newwaittime = 0;
-            mproffset = 0;
-            newmproffset = 120;
-            chnloffset = 0;
-            newchnloffset = 120;
-          }
-          cmdSend(16);
-        }
-        else if (page == MENU)
-          cmdSend(CMD_GET_MENU);  // cmdGetData();
-        else if (page == ERRORS)
-          cmdSend(CMD_GET_ERRORS);
-        else if (page == OPTIONS)
-          cmdSend(CMD_GET_PARAM);
-        else if (page == BATTERY_PROTECTION)
-          cmdSend(38);
-        // else if (page==11) cmdPalletConf();
-        countcharge++;
-        getchargetime = millis();
       }
     }
     if (millis() - blinkshuttnumInterval > 250)
@@ -1160,7 +1129,6 @@ void loop()
       if (page == UNLOAD_PALLETE_SUCC || page == UNLOAD_PALLETE_FAIL || page == ACCESS_DENIED)
       {
         delay(1200);
-        cmdSend(16);
         page = MAIN;
         isDisplayDirty = true;
       }
@@ -1381,7 +1349,6 @@ void keypadEvent(KeypadEvent key)
           newchnloffset = 120;
           delay(300);
           shuttnumst = shuttnum[shuttleNumber - 1];
-          cmdSend(16);
           hideshuttnum = 0;
         }
         if (page == MAIN)
@@ -1454,7 +1421,6 @@ void keypadEvent(KeypadEvent key)
             newchnloffset = 120;
             delay(300);
             // cmdStatus();
-            cmdSend(16);
             page = MAIN;  // toggle menu mode
             cursorPos = 1;
           }
@@ -1478,7 +1444,6 @@ void keypadEvent(KeypadEvent key)
             isFabala = true;
             delay(300);
             // cmdStatus();
-            cmdSend(16);
             page = MAIN;  // toggle menu mode
             cursorPos = 1;
           }
@@ -1486,9 +1451,6 @@ void keypadEvent(KeypadEvent key)
       }
       else
       {
-        cmdSend(16);
-        countcharge = 0;
-        getchargetime = millis();
       }
       break;
 
@@ -1514,9 +1476,6 @@ void keypadEvent(KeypadEvent key)
             }
             else if (page == MAIN)
             {
-              cmdSend(16);
-              countcharge = 0;
-              getchargetime = millis();
             }
             else
             {
@@ -1525,8 +1484,6 @@ void keypadEvent(KeypadEvent key)
                 page = ERRORS;
                 cursorPos = 1;
                 cmdSend(CMD_GET_ERRORS);
-                countcharge = 0;
-                getchargetime = millis();
               }
               else if (page == MENU && cursorPos == 2)
               {
@@ -1543,8 +1500,6 @@ void keypadEvent(KeypadEvent key)
                 page = OPTIONS;
                 cursorPos = 1;
                 cmdSend(CMD_GET_PARAM);
-                countcharge = 0;
-                getchargetime = millis();
               }
               else if (page == MENU && cursorPos == 7)
               {
@@ -1834,8 +1789,6 @@ void keypadEvent(KeypadEvent key)
               page = MENU;
               // cmdGetData();
               cmdSend(CMD_GET_MENU);
-              countcharge = 0;
-              getchargetime = millis();
             }
             else
             {
@@ -1850,9 +1803,6 @@ void keypadEvent(KeypadEvent key)
                 page = ENGINEERING_MENU;
               else
                 page = MAIN;
-              cmdSend(16);
-              countcharge = 0;
-              getchargetime = millis();
             }
             cursorPos = 1;
             break;

--- a/work_log.md
+++ b/work_log.md
@@ -173,3 +173,34 @@
 - Validated that `cmdSend` was bypassed for critical safety commands to ensure direct mapping to `ShuttleProtocol` enums.
 - Validated state transitions ensuring no "spamming" of move commands.
 - Confirmed safety stop is triggered on button release.
+
+
+Task 5: Context-Aware Telemetry Polling
+Goal: Transition from blindly blasting data requests to a smart, state-driven polling engine.
+
+Context:
+The legacy polling system was fragmented and used multiple counters (countcharge, cyclegetcharge, getchargetime) scattered across loop() and keypadEvent(). It often sent requests blindly (e.g., cmdSend(16)) on random key releases.
+
+Actions Taken:
+1.  **Established Dynamic Polling Engine**:
+    *   Added new global variables: `uint32_t lastPollTime`, `uint32_t currentPollInterval`, `uint32_t lastSensorPollTime`.
+    *   Implemented a unified, non-blocking polling logic in `loop()` of `PultV1_0_2.ino`.
+    *   The engine checks `!isManualMoving && !isOtaUpdating` before polling.
+
+2.  **Contextual Request Routing**:
+    *   The engine dynamically sets `currentPollInterval` based on `page`:
+        *   `MAIN`: 400ms (fast heartbeat).
+        *   `DEBUG_INFO`: 1500ms (slow heartbeat) + 300ms (fast sensor polling).
+        *   Other pages: 1500ms (background heartbeat).
+    *   Requests are queued using `queueRequest(SP::MSG_REQ_HEARTBEAT, shuttleNumber)`.
+    *   For `DEBUG_INFO`, a secondary timer polls `SP::MSG_REQ_SENSORS` every 300ms.
+
+3.  **Purged Legacy Polling Mess**:
+    *   Removed `uint8_t countcharge`, `uint8_t cyclegetcharge`, `unsigned long getchargetime` global variables.
+    *   Removed the legacy `if (millis() - getchargetime > 300)` polling block in `loop()`.
+    *   Cleaned up the `checkA0time` block in `loop()`, removing `cyclegetcharge` logic and `cmdSend(35/44)` calls, while preserving battery monitoring.
+    *   Removed all legacy `cmdSend(16)` calls from `keypadEvent()` (triggered on key releases or wake-up) and `loop()` (e.g., after unload).
+    *   Removed legacy `cmdSend(16)` and variable resets from `setup()`.
+
+Result:
+The system now uses a single, robust, state-aware polling mechanism that respects radio bandwidth and UI context. Legacy "blind blasting" code has been completely removed.


### PR DESCRIPTION
Implemented Task 5: Context-Aware Telemetry Polling.
Refactored `PultV1_0_2.ino` to use a dynamic polling engine.
Removed legacy polling variables and logic.
Cleaned up `cmdSend` calls in `keypadEvent`.

---
*PR created automatically by Jules for task [13302840248644532254](https://jules.google.com/task/13302840248644532254) started by @Driadix*