### PR TITLE
Refactor UI Core: Screen Interface and ScreenManager

### DIFF
--- a/Screen.h
+++ b/Screen.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <U8g2lib.h>
+#include "InputEvents.h"
+
+// Abstract base class for all UI screens
+class Screen {
+public:
+    virtual ~Screen() {}
+
+    // Fired when the screen is pushed to the top of the stack
+    virtual void onEnter() {}
+
+    // Fired when the screen is popped from the stack
+    virtual void onExit() {}
+
+    // Renders the layout to the display buffer. Only called if needsRedraw() is true.
+    virtual void draw(U8G2& display) = 0;
+
+    // Processes logical inputs routed from the InputManager
+    virtual void handleInput(InputEvent event) = 0;
+
+    // Called at a fixed frequency (e.g. 20Hz) to evaluate logic, animations, or check DataManager flags.
+    // Implementations should check DataManager dirty flags and call setDirty() if needed.
+    virtual void tick() = 0;
+
+    // Returns true if the screen needs to be redrawn
+    bool needsRedraw() const {
+        return _needsRedraw;
+    }
+
+    // Forces a redraw on the next tick
+    void setDirty() {
+        _needsRedraw = true;
+    }
+
+    // Clears the dirty flag (called by ScreenManager after a successful render)
+    void clearDirty() {
+        _needsRedraw = false;
+    }
+
+protected:
+    bool _needsRedraw = true; // Default to true so it draws on first load
+};

--- a/ScreenManager.cpp
+++ b/ScreenManager.cpp
@@ -1,0 +1,74 @@
+#include "ScreenManager.h"
+#include <Arduino.h> // For debugging Serial if needed
+
+ScreenManager& ScreenManager::getInstance() {
+    static ScreenManager instance;
+    return instance;
+}
+
+ScreenManager::ScreenManager() : _topIndex(-1) {
+    // Initialize stack with nulls
+    for (int i = 0; i < MAX_STACK_SIZE; i++) {
+        _stack[i] = nullptr;
+    }
+}
+
+void ScreenManager::push(Screen* s) {
+    if (_topIndex < MAX_STACK_SIZE - 1 && s != nullptr) {
+        _topIndex++;
+        _stack[_topIndex] = s;
+        s->onEnter();
+        s->setDirty(); // Ensure it draws
+    } else {
+        // Stack overflow or null pointer
+        // In a real system we might log this or handle it
+    }
+}
+
+void ScreenManager::pop() {
+    if (_topIndex >= 0) {
+        _stack[_topIndex]->onExit();
+        _stack[_topIndex] = nullptr; // Clear the pointer
+        _topIndex--;
+
+        if (_topIndex >= 0) {
+            _stack[_topIndex]->setDirty(); // Redraw the underlying screen
+        }
+    }
+}
+
+void ScreenManager::popToRoot() {
+    while (_topIndex > 0) {
+        _stack[_topIndex]->onExit();
+        _stack[_topIndex] = nullptr;
+        _topIndex--;
+    }
+    // Now _topIndex is 0 (or -1 if empty).
+    // If it's 0, make sure it redraws.
+    if (_topIndex == 0 && _stack[0] != nullptr) {
+        _stack[0]->setDirty();
+    }
+}
+
+void ScreenManager::handleInput(InputEvent event) {
+    if (_topIndex >= 0 && _stack[_topIndex] != nullptr) {
+        _stack[_topIndex]->handleInput(event);
+    }
+}
+
+void ScreenManager::tick(U8G2& display) {
+    if (_topIndex >= 0 && _stack[_topIndex] != nullptr) {
+        Screen* currentScreen = _stack[_topIndex];
+
+        // 1. Logical update
+        currentScreen->tick();
+
+        // 2. Dirty Flag Render Cascade
+        if (currentScreen->needsRedraw()) {
+            display.clearBuffer();
+            currentScreen->draw(display);
+            display.sendBuffer();
+            currentScreen->clearDirty();
+        }
+    }
+}

--- a/ScreenManager.h
+++ b/ScreenManager.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <U8g2lib.h>
+#include "Screen.h"
+#include "InputEvents.h"
+
+class ScreenManager {
+public:
+    static ScreenManager& getInstance();
+
+    // Navigation Stack Operations
+    void push(Screen* s);
+    void pop();
+    void popToRoot();
+
+    // Input Handling
+    void handleInput(InputEvent event);
+
+    // Main Loop Tick (Render Cascade)
+    void tick(U8G2& display);
+
+private:
+    ScreenManager(); // Private constructor for Singleton
+    ScreenManager(const ScreenManager&) = delete;
+    ScreenManager& operator=(const ScreenManager&) = delete;
+
+    static const int MAX_STACK_SIZE = 5;
+    Screen* _stack[MAX_STACK_SIZE];
+    int8_t _topIndex;
+};


### PR DESCRIPTION
Implemented Phase 3 of the UI refactor:
1.  **Screen Interface:** Defined the abstract `Screen` class with lifecycle methods (`onEnter`, `onExit`) and the dirty-flag render loop (`draw`, `tick`, `needsRedraw`).
2.  **Screen Manager:** Implemented the `ScreenManager` singleton to manage a static stack of screens (max depth 5) without dynamic allocation. It handles input routing and the render cascade to the U8G2 display.
3.  **Documentation:** Updated `display_refactor_log.md` with details on the new architecture.

This infrastructure runs alongside the existing legacy `PultV1_0_2.ino` logic, ready for the next phase of migrating individual screens.

---
*PR created automatically by Jules for task [3511364535552148507](https://jules.google.com/task/3511364535552148507) started by @Driadix*