### PR TITLE
Fix dead code, ScreenManager lifecycle, and UI redraw artifacts

### DIFF
--- a/EngineeringMenuScreen.cpp
+++ b/EngineeringMenuScreen.cpp
@@ -35,10 +35,10 @@ void EngineeringMenuScreen::provideMenuItem(uint8_t index, char* buffer) {
         case 3: strcpy(buffer, "Logging: Toggle"); break;
         case 4: strcpy(buffer, "Movement"); break;
         case 5: strcpy(buffer, "Change Channel"); break;
-        case 6: snprintf(buffer, 32, "Shuttle Len: %d", DataManager::getInstance().getConfig(SP::CFG_SHUTTLE_LEN)); break;
-        case 7: snprintf(buffer, 32, "Wait Time: %d", DataManager::getInstance().getConfig(SP::CFG_WAIT_TIME)); break;
-        case 8: snprintf(buffer, 32, "MPR Offset: %d", DataManager::getInstance().getConfig(SP::CFG_MPR_OFFSET)); break;
-        case 9: snprintf(buffer, 32, "Chnl Offset: %d", DataManager::getInstance().getConfig(SP::CFG_CHNL_OFFSET)); break;
+        case 6: snprintf(buffer, 32, "Shuttle Len: %-4d", DataManager::getInstance().getConfig(SP::CFG_SHUTTLE_LEN)); break;
+        case 7: snprintf(buffer, 32, "Wait Time: %-3d", DataManager::getInstance().getConfig(SP::CFG_WAIT_TIME)); break;
+        case 8: snprintf(buffer, 32, "MPR Offset: %-4d", DataManager::getInstance().getConfig(SP::CFG_MPR_OFFSET)); break;
+        case 9: snprintf(buffer, 32, "Chnl Offset: %-4d", DataManager::getInstance().getConfig(SP::CFG_CHNL_OFFSET)); break;
         case 10: strcpy(buffer, "Stats"); break;
         case 11: strcpy(buffer, "Back"); break;
         default: buffer[0] = '\0'; break;

--- a/OptionsScreen.cpp
+++ b/OptionsScreen.cpp
@@ -33,15 +33,15 @@ void OptionsScreen::onEvent(SystemEvent event) {
 
 void OptionsScreen::provideMenuItem(uint8_t index, char* buffer) {
     switch(index) {
-        case 0: snprintf(buffer, 32, "MPR: %ld mm", (long)DataManager::getInstance().getConfig(SP::CFG_INTER_PALLET)); break;
+        case 0: snprintf(buffer, 32, "MPR: %-4ld mm", (long)DataManager::getInstance().getConfig(SP::CFG_INTER_PALLET)); break;
         case 1: {
             bool rev = DataManager::getInstance().getConfig(SP::CFG_REVERSE_MODE) != 0;
-            snprintf(buffer, 32, "Rev Mode: %s", rev ? "<<" : ">>");
+            snprintf(buffer, 32, "Rev Mode: %-3s", rev ? "<<" : ">>");
             break;
         }
-        case 2: snprintf(buffer, 32, "Max Speed: %ld%%", (long)DataManager::getInstance().getConfig(SP::CFG_MAX_SPEED) / 10); break;
-        case 3: snprintf(buffer, 32, "Change ID: %d", DataManager::getInstance().getShuttleNumber()); break;
-        case 4: snprintf(buffer, 32, "Batt Prot: %ld%%", (long)DataManager::getInstance().getConfig(SP::CFG_MIN_BATT)); break;
+        case 2: snprintf(buffer, 32, "Max Speed: %-3ld%%", (long)DataManager::getInstance().getConfig(SP::CFG_MAX_SPEED) / 10); break;
+        case 3: snprintf(buffer, 32, "Change ID: %-3d", DataManager::getInstance().getShuttleNumber()); break;
+        case 4: snprintf(buffer, 32, "Batt Prot: %-3ld%%", (long)DataManager::getInstance().getConfig(SP::CFG_MIN_BATT)); break;
         case 5: strcpy(buffer, "Engineering Menu"); break;
         case 6: strcpy(buffer, "Save Params"); break;
         case 7: strcpy(buffer, "Back"); break;
@@ -72,13 +72,6 @@ void OptionsScreen::draw(U8G2& display) {
     // But to respect the "Partial" goal:
     // I will let it overdraw.
     // To prevent artifacts, I should clear the list area.
-
-    if (!_fullRedrawNeeded) {
-        // Clear list area to be safe
-         display.setDrawColor(0);
-         display.drawBox(0, 16, 128, 64-16);
-         display.setDrawColor(1);
-    }
 
     _statusBar.draw(display, 0, 0);
     _menuList.draw(display, 0, 16);

--- a/PultNew.ino
+++ b/PultNew.ino
@@ -136,17 +136,8 @@ void setup()
 }
 #pragma endregion
 
-bool isFabala = true;
-
 void loop()
 {
-  if (isFabala)
-  {
-    // configArray removed, skip print
-    isFabala = false;
-    Serial.print(" | ");
-  }
-
   if (isUpdateStarted)
   {
     ElegantOTA.loop();

--- a/ScreenManager.cpp
+++ b/ScreenManager.cpp
@@ -63,6 +63,7 @@ void ScreenManager::popToRoot() {
     // Now _topIndex is 0 (or -1 if empty).
     // If it's 0, make sure it redraws.
     if (_topIndex == 0 && _stack[0] != nullptr) {
+        _stack[0]->onEnter();
         _stack[0]->setDirty();
     }
 }


### PR DESCRIPTION
This PR addresses three main issues:
1.  **Dead Code Removal**: Removed the `isFabala` flag and its associated block in the main `loop()` of `PultNew.ino`. The requirement to wait for radio initialization is handled by the synchronous `initRadio()` call in `setup()`.
2.  **Screen Lifecycle Fix**: Fixed a bug in `ScreenManager::popToRoot()` where the root screen would not be re-initialized (i.e., `onEnter()` was not called), causing it to miss event subscriptions (like telemetry updates).
3.  **UI Rendering Optimization**: Improved the redraw strategy for `OptionsScreen` and `EngineeringMenuScreen`. Instead of using `drawBox` to clear previous text (which can cause flicker), the code now uses space-padded `snprintf` format strings (e.g., `%-4ld`) to overwrite old values cleanly. This matches the requested "Industrial Grade Fix".

---
*PR created automatically by Jules for task [7252705689154153816](https://jules.google.com/task/7252705689154153816) started by @Driadix*