### PR TITLE
Implement Clean Slate Architecture with Hardware SPI

### DIFF
--- a/DashboardScreen.h
+++ b/DashboardScreen.h
@@ -24,4 +24,9 @@ private:
     String _manualCommand;
     uint32_t _queueFullTimer;
     bool _showQueueFull;
+
+    // Animation State
+    uint8_t _animX;
+    uint8_t _animFlagX;
+    uint32_t _lastAnimTick;
 };

--- a/NumericSpinnerWidget.cpp
+++ b/NumericSpinnerWidget.cpp
@@ -52,11 +52,6 @@ bool NumericSpinnerWidget::handleInput(InputEvent event) {
 }
 
 void NumericSpinnerWidget::draw(U8G2& display, uint8_t x, uint8_t y) {
-    // Clear background
-    display.setDrawColor(0);
-    display.drawBox(x, y, _width, _height);
-    display.setDrawColor(1);
-
     display.setFont(u8g2_font_9x15_t_cyrillic); // Larger font for numbers
     // 9x15 font. Baseline approx 12px from top.
 

--- a/OptionsScreen.cpp
+++ b/OptionsScreen.cpp
@@ -10,7 +10,6 @@ OptionsScreen::OptionsScreen()
 }
 
 void OptionsScreen::onEnter() {
-    Screen::onEnter();
     EventBus::subscribe(this);
 
     // Request config params to ensure fresh data
@@ -21,7 +20,6 @@ void OptionsScreen::onEnter() {
 }
 
 void OptionsScreen::onExit() {
-    Screen::onExit();
     EventBus::unsubscribe(this);
 }
 
@@ -50,29 +48,6 @@ void OptionsScreen::provideMenuItem(uint8_t index, char* buffer) {
 }
 
 void OptionsScreen::draw(U8G2& display) {
-    if (_fullRedrawNeeded) {
-        display.clearBuffer();
-    }
-
-    // Partial updates: We should clear if needed.
-    // ListWidget draws items.
-    // If we rely on _fullRedrawNeeded, it clears.
-    // If partial (config update), we redraw everything over previous.
-    // U8g2 without clearBuffer might leave artifacts if text length decreases.
-    // ScrollingListWidget should ideally clear its row.
-    // But since this screen is simple, full redraw on update is acceptable or we rely on overwriting with spaces?
-    // "MPR: 100 mm" -> "MPR: 90 mm ".
-    // Creating "clearing" strings is annoying.
-    // The user suggested drawing black box.
-    // ScrollingListWidget doesn't support that yet.
-    // For now, let's force full redraw on config change?
-    // `setDirty()` doesn't set `_fullRedrawNeeded`.
-    // But `OptionsScreen` covers full screen.
-    // If I want to clear, I can do `display.clearBuffer()` here manually if I want.
-    // But to respect the "Partial" goal:
-    // I will let it overdraw.
-    // To prevent artifacts, I should clear the list area.
-
     _statusBar.draw(display, 0, 0);
     _menuList.draw(display, 0, 16);
 }

--- a/PultNew.ino
+++ b/PultNew.ino
@@ -28,7 +28,7 @@ int addr0 = 0;
 
 // Config Array Replaced by Local Generation in initRadio()
 uint8_t logWrite = 0;
-U8G2_SSD1306_128X64_NONAME_F_4W_SW_SPI u8g2(U8G2_R0, /* clock=*/18, /* data=*/23, /* cs=*/2, /* dc=*/19, /* reset=*/4);
+U8G2_SSD1306_128X64_NONAME_F_4W_HW_SPI u8g2(U8G2_R0, /* cs=*/ 2, /* dc=*/ 19, /* reset=*/ 4);
 #define R_VERSION   " v1.0 2023"
 
 int pin_code = 1441;

--- a/Screen.h
+++ b/Screen.h
@@ -9,16 +9,13 @@ public:
     virtual ~Screen() {}
 
     // Fired when the screen is pushed to the top of the stack
-    virtual void onEnter() {
-        _fullRedrawNeeded = true;
-    }
+    virtual void onEnter() {}
 
     // Fired when the screen is popped from the stack
     virtual void onExit() {}
 
     // Renders the layout to the display buffer. Only called if needsRedraw() is true.
-    // NOTE: ScreenManager no longer clears the buffer automatically.
-    // If _fullRedrawNeeded is true, the implementation MUST clear the buffer (display.clearBuffer()).
+    // ScreenManager automatically clears the buffer before calling this.
     virtual void draw(U8G2& display) = 0;
 
     // Processes logical inputs routed from the InputManager
@@ -44,10 +41,8 @@ public:
     // Clears the dirty flag (called by ScreenManager after a successful render)
     void clearDirty() {
         _needsRedraw = false;
-        _fullRedrawNeeded = false;
     }
 
 protected:
     bool _needsRedraw = true; // Default to true so it draws on first load
-    bool _fullRedrawNeeded = true; // Signals that a full clear/redraw is required
 };

--- a/ScreenManager.cpp
+++ b/ScreenManager.cpp
@@ -83,7 +83,7 @@ void ScreenManager::tick(U8G2& display) {
 
         // 2. Dirty Flag Render Cascade
         if (currentScreen->needsRedraw()) {
-            // Note: Screens are responsible for clearBuffer() if needed (e.g. on full redraw)
+            display.clearBuffer();
             currentScreen->draw(display);
             display.sendBuffer();
             currentScreen->clearDirty();

--- a/ScrollingListWidget.cpp
+++ b/ScrollingListWidget.cpp
@@ -62,11 +62,6 @@ bool ScrollingListWidget::handleInput(InputEvent event) {
 }
 
 void ScrollingListWidget::draw(U8G2& display, uint8_t x, uint8_t y) {
-    // Clear background
-    display.setDrawColor(0);
-    display.drawBox(x, y, _width, _height);
-    display.setDrawColor(1);
-
     display.setFont(u8g2_font_6x13_t_cyrillic);
     const uint8_t lineHeight = 14;
 

--- a/StatusBarWidget.cpp
+++ b/StatusBarWidget.cpp
@@ -4,11 +4,6 @@
 void StatusBarWidget::draw(U8G2& display, uint8_t x, uint8_t y) {
     const auto& telemetry = DataManager::getInstance().getTelemetry();
 
-    // Clear background for partial redraw
-    display.setDrawColor(0);
-    display.drawBox(x, y, 128, 14); // Use fixed size or _width/_height
-    display.setDrawColor(1);
-
     display.setFont(u8g2_font_6x13_t_cyrillic);
     display.setDrawColor(1);
 


### PR DESCRIPTION
This PR implements the "Clean Slate + Hardware SPI + Dirty Flag" architecture.

Key changes:
1.  **Hardware SPI**: Switched to `U8G2_SSD1306_128X64_NONAME_F_4W_HW_SPI` in `PultNew.ino` using VSPI pins.
2.  **Core Architecture**:
    *   `ScreenManager::tick` now handles `clearBuffer()` and `sendBuffer()`.
    *   Removed `_fullRedrawNeeded` from `Screen` base class.
3.  **Code Purge**:
    *   Removed manual background clearing (`drawBox` with color 0) from `DashboardScreen`, `OptionsScreen`, `StatusBarWidget`, `NumericSpinnerWidget`, and `ScrollingListWidget`.
    *   Verified other screens (`StatsScreen`, `EngineeringMenuScreen`, etc.) are compliant.
4.  **Dashboard Animation**:
    *   Moved stateful static variables (`x`, `flagx`) from `drawShuttleStatus` to member variables (`_animX`, `_animFlagX`).
    *   Implemented non-blocking animation updates in `DashboardScreen::tick()`.


---
*PR created automatically by Jules for task [1683933946136077680](https://jules.google.com/task/1683933946136077680) started by @Driadix*