### PR TITLE
Fix compilation errors: ambiguous inheritance and type mismatches

### DIFF
--- a/DashboardScreen.cpp
+++ b/DashboardScreen.cpp
@@ -68,7 +68,7 @@ void DashboardScreen::draw(U8G2& display) {
 
     // 4. Manual Command
     if (_isManualMoving) {
-        display.drawStr(85, 40, _manualCommand);
+        display.drawStr(85, 40, _manualCommand.c_str());
     }
 
     // 5. Draw Animation

--- a/DebugInfoScreen.h
+++ b/DebugInfoScreen.h
@@ -4,7 +4,7 @@
 #include "DataManager.h"
 #include "EventBus.h"
 
-class DebugInfoScreen : public Screen, public EventListener {
+class DebugInfoScreen : public Screen {
 public:
     DebugInfoScreen();
 

--- a/EngineeringMenuScreen.h
+++ b/EngineeringMenuScreen.h
@@ -5,7 +5,7 @@
 #include "DataManager.h"
 #include "EventBus.h"
 
-class EngineeringMenuScreen : public Screen, public EventListener {
+class EngineeringMenuScreen : public Screen {
 public:
     EngineeringMenuScreen();
 

--- a/ErrorsScreen.h
+++ b/ErrorsScreen.h
@@ -5,7 +5,7 @@
 #include "DataManager.h"
 #include "EventBus.h"
 
-class ErrorsScreen : public Screen, public EventListener {
+class ErrorsScreen : public Screen {
 public:
     ErrorsScreen();
 

--- a/MainMenuScreen.h
+++ b/MainMenuScreen.h
@@ -5,7 +5,7 @@
 #include "DataManager.h"
 #include "EventBus.h"
 
-class MainMenuScreen : public Screen, public EventListener {
+class MainMenuScreen : public Screen {
 public:
     MainMenuScreen();
 

--- a/MovementScreen.h
+++ b/MovementScreen.h
@@ -5,7 +5,7 @@
 #include "DataManager.h"
 #include "EventBus.h"
 
-class MovementScreen : public Screen, public EventListener {
+class MovementScreen : public Screen {
 public:
     MovementScreen();
 
@@ -24,7 +24,7 @@ private:
     static void provideMenuItem(uint8_t index, char* buffer);
 };
 
-class MovementAxisScreen : public Screen, public EventListener {
+class MovementAxisScreen : public Screen {
 public:
     MovementAxisScreen();
 

--- a/StatsScreen.cpp
+++ b/StatsScreen.cpp
@@ -28,16 +28,16 @@ void StatsScreen::draw(U8G2& display) {
 
     char buf[32];
 
-    snprintf(buf, sizeof(buf), "Dist:   %-6lu m", stats.totalDist / 1000);
+    snprintf(buf, sizeof(buf), "Dist:   %-6lu m", (unsigned long)(stats.totalDist / 1000));
     display.drawStr(0, 25, buf);
 
-    snprintf(buf, sizeof(buf), "Cycles: %-6lu", stats.loadCounter);
+    snprintf(buf, sizeof(buf), "Cycles: %-6lu", (unsigned long)stats.loadCounter);
     display.drawStr(0, 37, buf);
 
     snprintf(buf, sizeof(buf), "Crashes: %-5u", stats.crashCount);
     display.drawStr(0, 49, buf);
 
-    snprintf(buf, sizeof(buf), "Uptime:  %-6lu m", stats.totalUptimeMinutes);
+    snprintf(buf, sizeof(buf), "Uptime:  %-6lu m", (unsigned long)stats.totalUptimeMinutes);
     display.drawStr(0, 61, buf);
 }
 

--- a/StatsScreen.h
+++ b/StatsScreen.h
@@ -4,7 +4,7 @@
 #include "DataManager.h"
 #include "EventBus.h"
 
-class StatsScreen : public Screen, public EventListener {
+class StatsScreen : public Screen {
 public:
     StatsScreen();
 


### PR DESCRIPTION
Resolved compilation errors preventing the project from building. 
The main issue was ambiguous inheritance where screen classes inherited `EventListener` both directly and via the `Screen` base class. 
Also fixed a type mismatch where a `String` was passed to `drawStr` which expects `const char*`, and corrected printf format specifiers for `uint32_t` types.

---
*PR created automatically by Jules for task [13599279751220744670](https://jules.google.com/task/13599279751220744670) started by @Driadix*