### PR TITLE
Fix compilation warnings in EventBus and DataManager

### DIFF
--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -7,7 +7,10 @@ DataManager& DataManager::getInstance() {
 }
 
 DataManager::DataManager()
-    : _isOtaUpdating(false),
+    : _transport(nullptr),
+      _model(),
+      _commLink(&_transport, &_model),
+      _isOtaUpdating(false),
       _isManualMoving(false),
       _pollContext(PollContext::NORMAL),
       _lastPollTime(0),
@@ -16,10 +19,7 @@ DataManager::DataManager()
       _manualHeartbeatTimer(0),
       _currentPollInterval(1500),
       _remoteBatteryLevel(0),
-      _radioChannel(0),
-      _transport(nullptr),
-      _model(),
-      _commLink(&_transport, &_model)
+      _radioChannel(0)
 {
 }
 

--- a/EventBus.cpp
+++ b/EventBus.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "EventBus.h"
 
 EventListener* EventBus::_listeners[EventBus::MAX_LISTENERS] = {nullptr};


### PR DESCRIPTION
This change fixes two compilation warnings:
1.  A warning about `#pragma once` being used in `EventBus.cpp`. This directive is intended for header files and has been removed from the source file.
2.  A `-Wreorder` warning in `DataManager.cpp`. The member initialization list in the constructor was reordered to strictly match the declaration order of members in `DataManager.h`. Specifically, `_transport`, `_model`, and `_commLink` were moved to the beginning of the list, and `_radioChannel` was moved to the end.


---
*PR created automatically by Jules for task [15729085604360246043](https://jules.google.com/task/15729085604360246043) started by @Driadix*