### PR TITLE
Fix compilation errors in EventBus and DashboardScreen

### DIFF
--- a/DashboardScreen.cpp
+++ b/DashboardScreen.cpp
@@ -39,12 +39,13 @@ void DashboardScreen::draw(U8G2& display) {
     display.setFont(u8g2_font_6x13_t_cyrillic);
     display.setDrawColor(1); // White text
 
+    char buf[64];
+
     if (!DataManager::getInstance().isConnected()) {
         display.drawStr(0, 25, "Подключение..."); // Connecting...
         // Hide movement animations when disconnected
     } else {
         const SP::TelemetryPacket& cachedTelemetry = DataManager::getInstance().getTelemetry();
-        char buf[64];
 
         // 2. Main Status
         if (cachedTelemetry.shuttleStatus == 13) {

--- a/EventBus.h
+++ b/EventBus.h
@@ -11,7 +11,10 @@ enum class SystemEvent {
     ERROR_OCCURRED,
     BATTERY_LOW,
     QUEUE_FULL,
-    QUEUE_OK
+    QUEUE_OK,
+    CONNECTION_LOST,
+    CONNECTION_RESTORED,
+    LOCAL_BATT_UPDATED
 };
 
 // Interface for listeners


### PR DESCRIPTION
Added CONNECTION_LOST, CONNECTION_RESTORED, and LOCAL_BATT_UPDATED to SystemEvent in EventBus.h. Moved declaration of 'buf' to the beginning of DashboardScreen::draw in DashboardScreen.cpp to fix scope error.

---
*PR created automatically by Jules for task [1654682547399639435](https://jules.google.com/task/1654682547399639435) started by @Driadix*