### PR TITLE
Implement Transient Action Bar and Command Preemption

### DIFF
--- a/CommLink.h
+++ b/CommLink.h
@@ -2,6 +2,7 @@
 #include "ITransport.h"
 #include "TelemetryModel.h"
 #include "ShuttleProtocolTypes.h"
+#include "EventBus.h"
 
 class CommLink {
 public:
@@ -14,6 +15,9 @@ public:
     bool sendRequest(uint8_t msgID);
     bool sendConfigSet(uint8_t paramID, int32_t value);
     bool sendConfigGet(uint8_t paramID);
+
+    // Clears any pending user commands (preemption)
+    void clearPendingCommands();
 
     bool isQueueFull() const;
     bool isWaitingForAck() const;
@@ -37,6 +41,7 @@ private:
         uint8_t seqNum;
         uint32_t lastTxTime;
         uint8_t retryCount;
+        bool cancelled;
     };
     static const uint8_t MAX_JOBS = 8;
     TxJob _jobQueue[MAX_JOBS];
@@ -52,6 +57,7 @@ private:
     void processTxQueue();
     void handleRx();
     void processIncomingAck(uint8_t seq, SP::AckPacket* ack);
+    bool isUserCommand(uint8_t msgID) const;
 
     // Buffer management
     uint16_t getFreeSpace() const;

--- a/DashboardScreen.h
+++ b/DashboardScreen.h
@@ -34,4 +34,9 @@ private:
     uint8_t _animX;
     uint8_t _animFlagX;
     uint32_t _lastAnimTick;
+
+    // Action Bar State
+    String _actionMsg;
+    String _actionStatus;
+    uint32_t _actionMsgTimer;
 };

--- a/DataManager.h
+++ b/DataManager.h
@@ -26,6 +26,7 @@ public:
     bool sendCommand(SP::CmdType cmd, int32_t arg1 = 0, int32_t arg2 = 0);
     bool requestConfig(SP::ConfigParamID paramID);
     bool setConfig(SP::ConfigParamID paramID, int32_t value);
+    SP::CmdType getLastUserCommandType() const;
 
     // --- Data Getters (Read-Only) ---
     const SP::TelemetryPacket& getTelemetry() const;
@@ -79,4 +80,5 @@ private:
     int _remoteBatteryLevel;
     bool _isCharging;
     uint8_t _radioChannel;
+    SP::CmdType _lastUserCommandType;
 };

--- a/DebugUtils.cpp
+++ b/DebugUtils.cpp
@@ -40,6 +40,9 @@ const char* DebugUtils::getSystemEventName(SystemEvent event) {
         case SystemEvent::CONNECTION_LOST:     return "CONNECTION_LOST";
         case SystemEvent::CONNECTION_RESTORED: return "CONNECTION_RESTORED";
         case SystemEvent::LOCAL_BATT_UPDATED:  return "LOCAL_BATT_UPDATED";
+        case SystemEvent::CMD_DISPATCHED:      return "CMD_DISPATCHED";
+        case SystemEvent::CMD_ACKED:           return "CMD_ACKED";
+        case SystemEvent::CMD_FAILED:          return "CMD_FAILED";
         default:                               return "UNKNOWN_SYS_EVENT";
     }
 }
@@ -68,5 +71,40 @@ const char* DebugUtils::getTxStateName(CommLink::TxState state) {
         case CommLink::TxState::WAITING_ACK:   return "WAITING_ACK";
         case CommLink::TxState::TIMEOUT_ERROR: return "TIMEOUT_ERROR";
         default:                               return "UNKNOWN_STATE";
+    }
+}
+
+const char* DebugUtils::getUICommandName(uint8_t cmdType) {
+    switch (cmdType) {
+        case SP::CMD_STOP:            return "Стоп";
+        case SP::CMD_STOP_MANUAL:     return "Стоп (Р)";
+        case SP::CMD_MOVE_RIGHT_MAN:  return "Вправо";
+        case SP::CMD_MOVE_LEFT_MAN:   return "Влево";
+        case SP::CMD_LIFT_UP:         return "Подъем";
+        case SP::CMD_LIFT_DOWN:       return "Спуск";
+        case SP::CMD_LOAD:            return "Загрузка";
+        case SP::CMD_UNLOAD:          return "Выгрузка";
+        case SP::CMD_MOVE_DIST_R:     return "Движение";
+        case SP::CMD_MOVE_DIST_F:     return "Движение";
+        case SP::CMD_CALIBRATE:       return "Калибр.";
+        case SP::CMD_DEMO:            return "Демо";
+        case SP::CMD_COUNT_PALLETS:   return "Счет пал.";
+        case SP::CMD_SAVE_EEPROM:     return "Сохр. настр.";
+        case SP::CMD_COMPACT_F:       return "Уплотнение";
+        case SP::CMD_COMPACT_R:       return "Уплотнение";
+        case SP::CMD_GET_CONFIG:      return "Чтение настр.";
+        case SP::CMD_EVACUATE_ON:     return "Эвакуация";
+        case SP::CMD_LONG_LOAD:       return "Длин. Загр.";
+        case SP::CMD_LONG_UNLOAD:     return "Длин. Выгр.";
+        case SP::CMD_LONG_UNLOAD_QTY: return "Длин. Выгр.";
+        case SP::CMD_RESET_ERROR:     return "Сброс ош.";
+        case SP::CMD_MANUAL_MODE:     return "Ручной реж.";
+        case SP::CMD_LOG_MODE:        return "Лог реж.";
+        case SP::CMD_HOME:            return "Домой";
+        case SP::CMD_PING:            return "Пинг";
+        case SP::CMD_FIRMWARE_UPDATE: return "Обновление";
+        case SP::CMD_SYSTEM_RESET:    return "Сброс сист.";
+        case SP::CMD_SET_DATETIME:    return "Уст. время";
+        default:                      return "Команда";
     }
 }

--- a/DebugUtils.h
+++ b/DebugUtils.h
@@ -11,4 +11,5 @@ public:
     static const char* getSystemEventName(SystemEvent event);
     static const char* getMsgIdName(uint8_t msgId);
     static const char* getTxStateName(CommLink::TxState state);
+    static const char* getUICommandName(uint8_t cmdType);
 };

--- a/EventBus.h
+++ b/EventBus.h
@@ -14,7 +14,10 @@ enum class SystemEvent {
     QUEUE_OK,
     CONNECTION_LOST,
     CONNECTION_RESTORED,
-    LOCAL_BATT_UPDATED
+    LOCAL_BATT_UPDATED,
+    CMD_DISPATCHED,
+    CMD_ACKED,
+    CMD_FAILED
 };
 
 // Interface for listeners


### PR DESCRIPTION
Implemented a Transient Action Bar (Toast Notification) on the DashboardScreen to replace static "Waiting for ACK..." text. The bar shows the current action (e.g., "Lifting... [ > ]"), updates on ACK ("Lifting [ OK ]"), or failure ("Lifting [ X ]"), and auto-hides.

Implemented Command Preemption ("Latest Intent Wins") in `CommLink`. `clearPendingCommands()` is called before dispatching a new user command, marking previous pending user commands as cancelled and aborting any active wait for ACK. This ensures the shuttle responds immediately to the latest operator input, improving safety and responsiveness.

Also added necessary localized strings in `DebugUtils`.

---
*PR created automatically by Jules for task [13890787749438891737](https://jules.google.com/task/13890787749438891737) started by @Driadix*