### PR TITLE
Implement Smart Heartbeats & Backoff strategy

### DIFF
--- a/CommLink.h
+++ b/CommLink.h
@@ -12,7 +12,7 @@ public:
 
     // --- Sending Methods ---
     bool sendCommand(SP::CommandPacket packet);
-    bool sendRequest(uint8_t msgID);
+    bool sendRequest(uint8_t msgID, uint8_t maxRetries = 3);
     bool sendConfigSet(uint8_t paramID, int32_t value);
     bool sendConfigGet(uint8_t paramID);
 
@@ -21,6 +21,7 @@ public:
 
     bool isQueueFull() const;
     bool isWaitingForAck() const;
+    bool hasPendingHeartbeat() const;
 
     enum class TxState { IDLE, WAITING_ACK, TIMEOUT_ERROR };
 
@@ -41,6 +42,7 @@ private:
         uint8_t seqNum;
         uint32_t lastTxTime;
         uint8_t retryCount;
+        uint8_t maxRetries;
         bool cancelled;
     };
     static const uint8_t MAX_JOBS = 8;
@@ -53,7 +55,7 @@ private:
     uint8_t _nextSeqNum;
 
     // --- Internal Helpers ---
-    bool enqueuePacket(uint8_t msgID, const void* payload, uint8_t payloadLen);
+    bool enqueuePacket(uint8_t msgID, const void* payload, uint8_t payloadLen, uint8_t maxRetries = 3);
     void processTxQueue();
     void handleRx();
     void processIncomingAck(uint8_t seq, SP::AckPacket* ack);


### PR DESCRIPTION
Implemented the "Smart Heartbeats & Backoff" strategy to optimize RF usage and system responsiveness.

Key changes:
1.  **Dynamic Polling**: Heartbeat interval switches between 400ms (connected) and 1500ms (disconnected/discovery).
2.  **Zero-Retry Heartbeats**: Heartbeats are now sent with `maxRetries = 0`. If they timeout, they are dropped silently without clogging the queue or triggering UI errors.
3.  **Single In-Flight Rule**: A new heartbeat is never queued if one is already pending or waiting for ACK.
4.  **Unconditional Timer Advance**: The heartbeat timer is reset every interval regardless of whether the packet was successfully queued, ensuring a consistent rhythm.
5.  **CommLink Enhancements**: Updated `CommLink` to support variable retries per job and exposed `hasPendingHeartbeat()` for the new logic.

This resolves the issue of queue blocking during signal loss and reduces unnecessary RF traffic when disconnected.

---
*PR created automatically by Jules for task [1419855898661388577](https://jules.google.com/task/1419855898661388577) started by @Driadix*