### PR TITLE
Implement Industrial Latency Strategy

### DIFF
--- a/CommLink.h
+++ b/CommLink.h
@@ -11,7 +11,7 @@ public:
     void tick();
 
     // --- Sending Methods ---
-    bool sendCommand(SP::CommandPacket packet);
+    bool sendCommand(SP::CommandPacket packet, uint8_t maxRetries = 1, uint16_t ackTimeoutMs = 250);
     bool sendRequest(uint8_t msgID, uint8_t maxRetries = 3);
     bool sendConfigSet(uint8_t paramID, int32_t value);
     bool sendConfigGet(uint8_t paramID);
@@ -43,6 +43,7 @@ private:
         uint32_t lastTxTime;
         uint8_t retryCount;
         uint8_t maxRetries;
+        uint16_t ackTimeoutMs;
         bool cancelled;
     };
     static const uint8_t MAX_JOBS = 8;
@@ -55,7 +56,7 @@ private:
     uint8_t _nextSeqNum;
 
     // --- Internal Helpers ---
-    bool enqueuePacket(uint8_t msgID, const void* payload, uint8_t payloadLen, uint8_t maxRetries = 3);
+    bool enqueuePacket(uint8_t msgID, const void* payload, uint8_t payloadLen, uint8_t maxRetries = 3, uint16_t ackTimeoutMs = 500);
     void processTxQueue();
     void handleRx();
     void processIncomingAck(uint8_t seq, SP::AckPacket* ack);

--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -119,12 +119,60 @@ bool DataManager::sendCommand(SP::CmdType cmd, int32_t arg1, int32_t arg2) {
     _commLink.clearPendingCommands();
     _lastUserCommandType = cmd;
 
+    // Industrial Latency Strategy
+    uint8_t retries = 1;
+    uint16_t timeout = 250;
+
+    switch (cmd) {
+        // 3. Safety Overrides (Aggressive Spamming)
+        case SP::CMD_STOP:
+        case SP::CMD_STOP_MANUAL:
+        case SP::CMD_EVACUATE_ON: // Assume evacuation is also critical
+            retries = 4;
+            timeout = 150;
+            break;
+
+        // 2. Discrete Actions (Guaranteed Delivery)
+        case SP::CMD_LIFT_UP:
+        case SP::CMD_LIFT_DOWN:
+        case SP::CMD_LOAD:
+        case SP::CMD_UNLOAD:
+        case SP::CMD_LONG_LOAD:
+        case SP::CMD_LONG_UNLOAD:
+        case SP::CMD_LONG_UNLOAD_QTY:
+        case SP::CMD_COMPACT_F:
+        case SP::CMD_COMPACT_R:
+        case SP::CMD_CALIBRATE:
+        case SP::CMD_HOME:
+        case SP::CMD_RESET_ERROR:
+        case SP::CMD_SAVE_EEPROM:
+        case SP::CMD_SET_DATETIME:
+            retries = 2;
+            timeout = 350;
+            break;
+
+        // 1. Continuous/Hazardous Movement (Fail Fast)
+        case SP::CMD_MOVE_RIGHT_MAN:
+        case SP::CMD_MOVE_LEFT_MAN:
+        case SP::CMD_MOVE_DIST_R:
+        case SP::CMD_MOVE_DIST_F:
+            retries = 1;
+            timeout = 250;
+            break;
+
+        // Default for others (Info requests, etc.)
+        default:
+            retries = 1;
+            timeout = 250;
+            break;
+    }
+
     SP::CommandPacket packet;
     packet.cmdType = (uint8_t)cmd;
     packet.arg1 = arg1;
     packet.arg2 = arg2;
 
-    bool sent = _commLink.sendCommand(packet);
+    bool sent = _commLink.sendCommand(packet, retries, timeout);
     if (sent) {
         EventBus::publish(SystemEvent::CMD_DISPATCHED);
     }


### PR DESCRIPTION
Implemented the "Industrial Latency Strategy" as requested.
- **CommLink Changes:** Added `ackTimeoutMs` to `TxJob` and updated `enqueuePacket` to accept this parameter. `processTxQueue` now uses this per-job timeout instead of a hardcoded value.
- **DataManager Changes:** Categorized commands in `sendCommand` and assigned specific timeouts and retries:
    - **Safety Overrides (e.g., STOP):** 4 retries, 150ms timeout.
    - **Discrete Actions (e.g., LIFT):** 2 retries, 350ms timeout.
    - **Continuous Movement (e.g., MOVE):** 1 retry, 250ms timeout.
This ensures optimal UX and safety by prioritizing critical commands and failing fast for continuous movements.

---
*PR created automatically by Jules for task [2200304995189258797](https://jules.google.com/task/2200304995189258797) started by @Driadix*