### PR TITLE
Safety Interlock and Disconnected State UI

### DIFF
--- a/DashboardScreen.cpp
+++ b/DashboardScreen.cpp
@@ -104,11 +104,19 @@ void DashboardScreen::draw(U8G2& display) {
         drawShuttleStatus(display, cachedTelemetry);
     }
 
-    // ACK Status / Action Bar
-    if (_actionMsg.length() > 0) {
-        char actionBuf[64];
-        snprintf(actionBuf, sizeof(actionBuf), "%s %s", _actionMsg.c_str(), _actionStatus.c_str());
-        display.drawStr(0, 52, actionBuf);
+    // ACK Status / Action Bar (Repurposed for Disconnected State)
+    if (!DataManager::getInstance().isConnected()) {
+        // Disconnected: Blink "Searching..."
+        if ((millis() / 500) % 2 == 0) {
+            display.drawStr(0, 52, "Поиск челнока...");
+        }
+    } else {
+        // Connected: Show Transient Action Bar
+        if (_actionMsg.length() > 0) {
+            char actionBuf[64];
+            snprintf(actionBuf, sizeof(actionBuf), "%s %s", _actionMsg.c_str(), _actionStatus.c_str());
+            display.drawStr(0, 52, actionBuf);
+        }
     }
     // Fallback: If no action message but waiting for ACK (e.g. background task?)
     // The user requested to replace static space with transient bar.
@@ -198,22 +206,22 @@ void DashboardScreen::handleInput(InputEvent event) {
              break;
 
         case InputEvent::LIFT_UP_PRESS: // 'E'
-            DataManager::getInstance().sendCommand(SP::CMD_LIFT_UP);
+            if (!DataManager::getInstance().sendCommand(SP::CMD_LIFT_UP)) success = false;
             break;
         case InputEvent::LIFT_DOWN_PRESS: // '9'
-            DataManager::getInstance().sendCommand(SP::CMD_LIFT_DOWN);
+            if (!DataManager::getInstance().sendCommand(SP::CMD_LIFT_DOWN)) success = false;
             break;
         case InputEvent::LOAD_PRESS: // '5'
-             DataManager::getInstance().sendCommand(SP::CMD_LOAD);
+             if (!DataManager::getInstance().sendCommand(SP::CMD_LOAD)) success = false;
              break;
         case InputEvent::LONG_LOAD_PRESS:
-             DataManager::getInstance().sendCommand(SP::CMD_LONG_LOAD);
+             if (!DataManager::getInstance().sendCommand(SP::CMD_LONG_LOAD)) success = false;
              break;
         case InputEvent::UNLOAD_PRESS: // 'C'
-             DataManager::getInstance().sendCommand(SP::CMD_UNLOAD);
+             if (!DataManager::getInstance().sendCommand(SP::CMD_UNLOAD)) success = false;
              break;
         case InputEvent::LONG_UNLOAD_PRESS:
-             DataManager::getInstance().sendCommand(SP::CMD_LONG_UNLOAD);
+             if (!DataManager::getInstance().sendCommand(SP::CMD_LONG_UNLOAD)) success = false;
              break;
 
         case InputEvent::BACK_PRESS: // '7'


### PR DESCRIPTION
Implemented the requested 2-layer safety architecture. 

1. **Logic Layer (DataManager.cpp):** Added a check in `sendCommand` to verify connection status. If disconnected, it logs a warning and returns `false`, preventing any command from being queued. This acts as a 'Hard Interlock'.
2. **UI Layer (DashboardScreen.cpp):** 
   - Updated `handleInput` to respect the return value of `sendCommand`, preventing the UI from assuming success if the interlock blocks the command.
   - Updated `draw` to visual indicate the disconnected state by repurposing the Action Bar area to display a blinking "Searching for shuttle..." message, while retaining the transient action bar functionality when connected.

---
*PR created automatically by Jules for task [8432957761071422612](https://jules.google.com/task/8432957761071422612) started by @Driadix*